### PR TITLE
Add comment generation

### DIFF
--- a/cmd/qry-gen/gen.go
+++ b/cmd/qry-gen/gen.go
@@ -110,7 +110,7 @@ func loadSql(cfg config) (b *bytes.Buffer, err error) {
 		b.WriteString(fmt.Sprintf("// %s\n", f.Name))
 
 		for idx, i := range f.Items {
-			if cfg.comment && unicode.IsUpper([]rune(i.Name)[0]) {
+			if cfg.comment && unicode.IsUpper(rune(i.Name[0])) {
 				if idx == 0 { // add empty line between f.Name and first comment
 					b.WriteString("\n")
 				}

--- a/cmd/qry-gen/gen_test.go
+++ b/cmd/qry-gen/gen_test.go
@@ -48,6 +48,10 @@ func TestGen(t *testing.T) {
 		bytes.Contains(b, []byte("\tDeleteUsersByIds = \"DELETE FROM `users` WHERE `user_id` IN ({ids});\"")),
 		bytes.Contains(b, []byte("\t// UglyMultiLineQuery query")),
 		bytes.Contains(b, []byte("\tUglyMultiLineQuery = \"SELECT * FROM `users` WHERE YEAR(`birth_date`) > 2000;\"")),
+		bytes.Contains(b, []byte("\t// EscapedJSONQuery query")),
+		bytes.Contains(b, []byte("\tEscapedJSONQuery = \"INSERT INTO \\\"data\\\" (id, \\\"data\\\") VALUES (1, '{\\\"test\\\": 1}'), (2, '{\\\"test\\\": 2}');\"")),
+		bytes.Contains(b, []byte("\t// EscapedByteaQuery query")),
+		bytes.Contains(b, []byte("\tEscapedByteaQuery = \"INSERT INTO bin (id, \\\"data\\\") VALUES (1, E'\\\\\\\\x3aaab6e7fb7245cc9785653a0d9ffc4a5ce0f974');\"")),
 	} {
 		if !c {
 			t.Errorf("check at idx %d has not passed", i)

--- a/cmd/qry-gen/gen_test.go
+++ b/cmd/qry-gen/gen_test.go
@@ -10,9 +10,10 @@ import (
 func TestGen(t *testing.T) {
 	var (
 		cfg = config{
-			dir: "../../testdata",
-			out: "gen.go",
-			fmt: true,
+			dir:     "../../testdata",
+			out:     "gen.go",
+			fmt:     true,
+			comment: true,
 		}
 
 		err error
@@ -37,11 +38,15 @@ func TestGen(t *testing.T) {
 
 	for i, c := range []bool{
 		bytes.Contains(b, []byte("package pkg")),
-		bytes.Contains(b, []byte("\t// one.sql")),
-		bytes.Contains(b, []byte("\tInsertUser  = \"INSERT INTO `users` (`name`) VALUES (?);\"")),
+		bytes.Contains(b, []byte("\t// one.sql\n\n")),
+		bytes.Contains(b, []byte("\t// InsertUser query")),
+		bytes.Contains(b, []byte("\tInsertUser = \"INSERT INTO `users` (`name`) VALUES (?);\"")),
+		bytes.Contains(b, []byte("\t// GetUserById query")),
 		bytes.Contains(b, []byte("\tGetUserById = \"SELECT * FROM `users` WHERE `user_id` = ?;\"")),
-		bytes.Contains(b, []byte("\t// two.sql")),
-		bytes.Contains(b, []byte("\tDeleteUsersByIds   = \"DELETE FROM `users` WHERE `user_id` IN ({ids});\"")),
+		bytes.Contains(b, []byte("\t// two.sql\n\n")),
+		bytes.Contains(b, []byte("\t// DeleteUsersByIds query")),
+		bytes.Contains(b, []byte("\tDeleteUsersByIds = \"DELETE FROM `users` WHERE `user_id` IN ({ids});\"")),
+		bytes.Contains(b, []byte("\t// UglyMultiLineQuery query")),
 		bytes.Contains(b, []byte("\tUglyMultiLineQuery = \"SELECT * FROM `users` WHERE YEAR(`birth_date`) > 2000;\"")),
 	} {
 		if !c {

--- a/qry_test.go
+++ b/qry_test.go
@@ -14,7 +14,7 @@ func TestDir(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(q) != 2 {
+	if len(q) != 3 {
 		t.Error("Expected 2 files")
 	}
 
@@ -36,6 +36,14 @@ func TestDir(t *testing.T) {
 
 	if q["two.sql"]["DeleteUsersByIds"] != "DELETE FROM `users` WHERE `user_id` IN ({ids});" {
 		t.Error("Invalid DeleteUsersByIds query")
+	}
+
+	if _, ok := q["three.sql"]; !ok {
+		t.Error("three.sql not loaded")
+	}
+
+	if q["three.sql"]["EscapedJSONQuery"] != "INSERT INTO \\\"data\\\" (id, \\\"data\\\") VALUES (1, '{\\\"test\\\": 1}'), (2, '{\\\"test\\\": 2}');" {
+		t.Error("Invalid EscapedJSONQuery query")
 	}
 }
 

--- a/qry_test.go
+++ b/qry_test.go
@@ -15,7 +15,7 @@ func TestDir(t *testing.T) {
 	}
 
 	if len(q) != 3 {
-		t.Error("Expected 2 files")
+		t.Error("Expected 3 files")
 	}
 
 	if _, ok := q["one.sql"]; !ok {

--- a/qry_test.go
+++ b/qry_test.go
@@ -45,6 +45,10 @@ func TestDir(t *testing.T) {
 	if q["three.sql"]["EscapedJSONQuery"] != "INSERT INTO \\\"data\\\" (id, \\\"data\\\") VALUES (1, '{\\\"test\\\": 1}'), (2, '{\\\"test\\\": 2}');" {
 		t.Error("Invalid EscapedJSONQuery query")
 	}
+
+	if q["three.sql"]["EscapedByteaQuery"] != "INSERT INTO bin (id, \\\"data\\\") VALUES (1, E'\\\\\\\\x3aaab6e7fb7245cc9785653a0d9ffc4a5ce0f974');" {
+		t.Error("Invalid EscapedByteaQuery query")
+	}
 }
 
 func TestDirInvalid(t *testing.T) {

--- a/queries.go
+++ b/queries.go
@@ -24,6 +24,7 @@ func normalize(q []byte) Query {
 	q = bytes.TrimSpace(q)
 	q = bytes.Replace(q, []byte("\n"), []byte(" "), -1)
 	q = rgxMultiSpace.ReplaceAll(q, []byte(" "))
+	q = bytes.Replace(q, []byte("\\"), []byte("\\\\"), -1)
 	q = bytes.Replace(q, []byte("\""), []byte("\\\""), -1)
 
 	return Query(q)

--- a/queries.go
+++ b/queries.go
@@ -24,6 +24,7 @@ func normalize(q []byte) Query {
 	q = bytes.TrimSpace(q)
 	q = bytes.Replace(q, []byte("\n"), []byte(" "), -1)
 	q = rgxMultiSpace.ReplaceAll(q, []byte(" "))
+	q = bytes.Replace(q, []byte("\""), []byte("\\\""), -1)
 
 	return Query(q)
 }

--- a/testdata/three.sql
+++ b/testdata/three.sql
@@ -1,0 +1,4 @@
+-- qry: EscapedJSONQuery
+INSERT INTO "data" (id, "data") VALUES
+  (1, '{"test": 1}'),
+  (2, '{"test": 2}');

--- a/testdata/three.sql
+++ b/testdata/three.sql
@@ -2,3 +2,7 @@
 INSERT INTO "data" (id, "data") VALUES
   (1, '{"test": 1}'),
   (2, '{"test": 2}');
+
+-- qry: EscapedByteaQuery
+INSERT INTO bin (id, "data") VALUES
+  (1, E'\\x3aaab6e7fb7245cc9785653a0d9ffc4a5ce0f974');


### PR DESCRIPTION
fixes #2 

Adding comment generation (for exported variables) as well as command option to disable it.

Generated file looks like this:
```go
const (
  // one.sql

  // InsertUser query
  InsertUser = "INSERT INTO `users` (`name`) VALUES (?);"
  // GetUserById query
  GetUserById = "SELECT * FROM `users` WHERE `user_id` = ?;"

  // two.sql

  // DeleteUsersByIds query
  DeleteUsersByIds = "DELETE FROM `users` WHERE `user_id` IN ({ids});"
  // UglyMultiLineQuery query
  UglyMultiLineQuery = "SELECT * FROM `users` WHERE YEAR(`birth_date`) > 2000;"
)
```