### PR TITLE
fix(cmd/qry-gen/gen.go): remove linter warnings for generated code

### DIFF
--- a/cmd/qry-gen/gen.go
+++ b/cmd/qry-gen/gen.go
@@ -101,7 +101,7 @@ func loadSql(cfg config) (b *bytes.Buffer, err error) {
 			return
 		}
 
-		b.WriteString(fmt.Sprintf("package %s\n\n", filepath.Base(cfg.pkg)))
+		b.WriteString(fmt.Sprintf("package %s\n\n ^// Code generated .* DO NOT EDIT.$ \n\n", filepath.Base(cfg.pkg)))
 	}
 
 	b.WriteString("const (\n")


### PR DESCRIPTION
fix issue #6: "Annotate generated file with 'code generated'"